### PR TITLE
Adding the .APNG extension

### DIFF
--- a/src/com/crossbowffs/usticker/StickerManager.kt
+++ b/src/com/crossbowffs/usticker/StickerManager.kt
@@ -16,7 +16,7 @@ import java.io.IOException
 object StickerManager {
     private const val PROVIDER_AUTHORITY = BuildConfig.APPLICATION_ID + ".provider"
     private const val DEFAULT_STICKER_DIR = "Pictures/Stickers/"
-    private val STICKER_EXTENSIONS = arrayOf("jpg", "jpeg", "png", "gif", "bmp")
+    private val STICKER_EXTENSIONS = arrayOf("jpg", "jpeg", "png", "apng", "gif", "bmp")
 
     /**
      * Checks whether a file (directory) is a child of a
@@ -123,7 +123,7 @@ object StickerManager {
      * Standard filesystem traversal algorithm, calls cb for each file
      * (not directory!) it finds. Does not yield/recurse into
      * files/directories with '.' as the first character in the name.
-     * Only finds JPG/PNG/GIF/BMP files.
+     * Only finds JPG/PNG/APNG/GIF/BMP files.
      */
     private fun traverseDirectory(packPath: String, dir: File, cb: (String, File) -> Unit) {
         dir.listFiles()


### PR DESCRIPTION
This should add recognition of .apng files to the sticker manager, which some animated stickers are formated in instead of .gif. GBoard and associated apps "should" natively support it, as it is the preferred sticker format of messaging apps like LINE, but right now I have no way to check and confirm it. Love the app!